### PR TITLE
Fixed the document loading state for IE10

### DIFF
--- a/dom-ops/lib/index.js
+++ b/dom-ops/lib/index.js
@@ -179,7 +179,7 @@ function nodesToArray(nodes) {
 }
 
 function whenReady(callback) {
-    if (document.readyState != 'loading') {
+    if (document.readyState != 'loading' && document.body != null) {
         callback();
     } else {
         document.addEventListener('DOMContentLoaded', callback);


### PR DESCRIPTION
On IE10, the document.readyState could be "interactive" but document.body
still being null. This will ensure it exists and avoid console errors
blocking the JS load.